### PR TITLE
Fix Docker image registry path in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,7 +78,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}/whatsapp-avatar-service
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## Summary

This PR fixes the Docker image registry path in the CI/CD workflow to ensure container images are pushed to the correct location.

## Problem

The current CI/CD configuration pushes Docker images to:
```
ghcr.io/pitchconnect/team-logo-combiner/whatsapp-avatar-service
```

But it should push to:
```
ghcr.io/pitchconnect/team-logo-combiner
```

## Solution

Removed the `/whatsapp-avatar-service` suffix from the Docker image name in `.github/workflows/ci-cd.yml` line 81.

## Changes Made

- Updated `.github/workflows/ci-cd.yml` to use the correct image registry path
- Changed `images: ghcr.io/${{ github.repository }}/whatsapp-avatar-service` to `images: ghcr.io/${{ github.repository }}`

## Testing

- [ ] CI/CD pipeline runs successfully
- [ ] Docker image is pushed to correct registry path
- [ ] All existing tests pass

## Impact

- Future builds will push Docker images to the correct registry location
- Existing images at the incorrect path will remain but won't be updated
- Low risk change that corrects the intended behavior

---
*This PR was created by an AI assistant following the repository's development workflow.*

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author